### PR TITLE
fix(translate_maps): prevent regex escapes from merging with adjacent…

### DIFF
--- a/config/maps/plugins/game/0ad/gather/fr-FR/FUZZY_MAP_pre.py
+++ b/config/maps/plugins/game/0ad/gather/fr-FR/FUZZY_MAP_pre.py
@@ -72,7 +72,7 @@ FUZZY_MAP_pre = [
     # EXAMPLE: viande
 
     ('gather meat',
-     r'^(viande|chasse|chasse|\w+ \w*a\w+fr|\w+ \w+a\w+fr|vestes|Oui|Oui bien|son avoir|viande|météo|lequel Amen|monter|volé|\w+\s\oser|nous avait)$',
+     r'^(viande|chasse|chasse|\w+ \w*a\w+fr|\w+ \w+a\w+fr|vestes|Oui|Oui bien|son avoir|viande|météo|lequel Amen|monter|volé|\w+\s\boser|nous avait)$',
      85,
      {
          'command_flags': re.IGNORECASE,

--- a/config/maps/plugins/it-begriffe/en-US/FUZZY_MAP_pre.py
+++ b/config/maps/plugins/it-begriffe/en-US/FUZZY_MAP_pre.py
@@ -297,11 +297,11 @@ FUZZY_MAP_pre = [
     ('AutoKey', r'\bCar\s*k\w+\b', 82, {'command_flags': re.IGNORECASE}),
     # EXAMPLE: 0 A.D.
 
-    ('0 A.D.', r'\or zewa d\b', 82, {'command_flags': re.IGNORECASE}),
+    ('0 A.D.', r'\bor zewa d\b', 82, {'command_flags': re.IGNORECASE}),
 
     # EXAMPLE: 0 A.D. game
 
-    ('0 A.D. spiel', r'\or zewa d game\W*\b', 82, {'command_flags': re.IGNORECASE}),
+    ('0 A.D. spiel', r'\bor zewa d game\W*\b', 82, {'command_flags': re.IGNORECASE}),
 
     # EXAMPLE: 0 A.D. game
 

--- a/config/maps/plugins/it-begriffe/es-ES/FUZZY_MAP_pre.py
+++ b/config/maps/plugins/it-begriffe/es-ES/FUZZY_MAP_pre.py
@@ -297,11 +297,11 @@ FUZZY_MAP_pre = [
     ('AutoKey', r'\bCoche\s*k\w+\b', 82, {'command_flags': re.IGNORECASE}),
     # EXAMPLE: 0 d.C.
 
-    ('0 A.D.', r'\o zewa d\b', 82, {'command_flags': re.IGNORECASE}),
+    ('0 A.D.', r'\bo zewa d\b', 82, {'command_flags': re.IGNORECASE}),
 
     # EXAMPLE: Juego 0 d.C.
 
-    ('0 A.D. spiel', r'\o zewa d juego\W*\b', 82, {'command_flags': re.IGNORECASE}),
+    ('0 A.D. spiel', r'\bo zewa d juego\W*\b', 82, {'command_flags': re.IGNORECASE}),
 
     # EXAMPLE: Juego 0 d.C.
 

--- a/config/maps/plugins/it-begriffe/fr-FR/FUZZY_MAP_pre.py
+++ b/config/maps/plugins/it-begriffe/fr-FR/FUZZY_MAP_pre.py
@@ -297,11 +297,11 @@ FUZZY_MAP_pre = [
     ('AutoKey', r'\bVoiture\s*k\w+\b', 82, {'command_flags': re.IGNORECASE}),
     # EXAMPLE: 0 après JC
 
-    ('0 A.D.', r'\ou zewa d\b', 82, {'command_flags': re.IGNORECASE}),
+    ('0 A.D.', r'\bou zewa d\b', 82, {'command_flags': re.IGNORECASE}),
 
     # EXAMPLE: 0 jeu après JC
 
-    ('0 A.D. spiel', r'\ou zewa d jeu\W*\b', 82, {'command_flags': re.IGNORECASE}),
+    ('0 A.D. spiel', r'\bou zewa d jeu\W*\b', 82, {'command_flags': re.IGNORECASE}),
 
     # EXAMPLE: 0 jeu après JC
 

--- a/config/maps/plugins/standard_actions/language_translator/de-DE/FUZZY_MAP_pre.py
+++ b/config/maps/plugins/standard_actions/language_translator/de-DE/FUZZY_MAP_pre.py
@@ -1,5 +1,5 @@
 # config/maps/plugins/standard_actions/language_translator/de-DE/FUZZY_MAP_pre.py
-import re # noqa: F401
+import re
 from pathlib import Path
 
 # This map uses a hybrid approach:

--- a/tools/translate_maps.py
+++ b/tools/translate_maps.py
@@ -164,12 +164,15 @@ def translate_regex_pattern(pattern: str, target_lang: str) -> str:
         # Preserve Python variables in f-strings like {unterstrichen}
         if token.startswith("{") and token.endswith("}"):
             return token
+        # Preserve regex escape sequences like \b, \d, \s, \w, \A, \Z —
+        # must not be glued onto an adjacent word (see fix for "\boder" -> "boder" bug)
+        if token.startswith("\\"):
+            return token
         if token.lower() in PRESERVED_KEYWORDS or len(token) <= 1:
             return token
         return translate_text(token, target_lang)
 
-    return re.sub(r"\{[a-zA-Z0-9_]+}|[a-zA-ZäöüÄÖÜß]+", replace_token, pattern)
-
+    return re.sub(r"\{[a-zA-Z0-9_]+}|\\[a-zA-Z]|[a-zA-ZäöüÄÖÜß]+", replace_token, pattern)
 def process_line(line: str, target_lang: str) -> str:
     """Processes and translates a single line of a Python map file."""
     if "# EXAMPLE:" in line:
@@ -212,8 +215,19 @@ def translate_map_file(source_path: Path, target_path: Path, target_lang: str, f
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
         final_content = HEADER_TEMPLATE + "\n".join(translated_lines) + "\n"
+
+        # Safety net: verify every raw-string regex pattern still compiles
+        # before writing a potentially broken map file to disk.
+        for m in re.finditer(r"r(['\"])((?:[^\\]|\\.)*?)\1", final_content):
+            try:
+                re.compile(m.group(2))
+            except re.error as e:
+                print(f"  [ERROR] Invalid regex produced for '{target_path.name}': {e} -> {m.group(2)!r}")
+                return False
+
         target_path.write_text(final_content, encoding="utf-8")
         return True
+    
     except Exception as e:
         print(f"Error translating '{source_path}': {e}")
         return False


### PR DESCRIPTION
… words

The tokenizer regex in translate_regex_pattern() treated a backslash escape (e.g. \b) followed directly by a word as one token (e.g. "boder"), sending the malformed string to the translator and losing the escape character in the result (\boder -> \o / \or / \ou instead of \bo / \bor / \bou).

Escape sequences (\b, \d, \s, \w, etc.) are now matched and preserved as their own token before word-splitting occurs.