### PR TITLE
fix(setup): ensure libharfbuzz-gobject0 dependency is installed for C…

### DIFF
--- a/setup/helper/install_cudatext.sh
+++ b/setup/helper/install_cudatext.sh
@@ -114,9 +114,16 @@ EOF"
     exit 3
   fi
 else  
-  
+  if command -v apt-get >/dev/null 2>&1; then
+    if ! dpkg -s libharfbuzz-gobject0 >/dev/null 2>&1; then
+      echo "[INFO] Installing missing CudaText dependency: libharfbuzz-gobject0"
+      ${SUDO} apt-get update -y && ${SUDO} apt-get install -y libharfbuzz-gobject0 || true
+    fi
+  fi
+
   # Detect architecture
   ARCH="$(uname -m)"
+  
   case "${ARCH}" in
   
 #    x86_64|amd64) TAR_NAME_PREFIX="cudatext-linux-gtk2-amd64" ;;

--- a/setup/ubuntu_setup.sh
+++ b/setup/ubuntu_setup.sh
@@ -70,7 +70,9 @@ fi
 echo "--> Installing other core dependencies…"
 sudo apt-get install -y \
     inotify-tools wget unzip portaudio19-dev python3-pip \
-    ffmpeg libnotify-bin xclip xvfb espeak-ng xdotool ripgrep        
+    ffmpeg libnotify-bin xclip xvfb espeak-ng xdotool ripgrep \
+    libharfbuzz-gobject0
+
 # --- 2. Python Virtual Environment ---
 # (This section remains unchanged)
 if [ ! -d ".venv" ]; then


### PR DESCRIPTION
…udaText

- Add libharfbuzz-gobject0 to apt package list in ubuntu_setup.sh
- Auto-detect and install missing libharfbuzz-gobject0 in install_cudatext.sh on Debian and Ubuntu systems