### PR TITLE
feat(memory): add emergency LanguageTool eviction and restart cooldow…

### DIFF
--- a/scripts/py/func/language_tool_cooldown.py
+++ b/scripts/py/func/language_tool_cooldown.py
@@ -1,0 +1,22 @@
+# CODE_LANGUAGE_DIRECTIVE: ENGLISH_ONLY
+"""Cooldown state manager for LanguageTool under memory pressure."""
+
+import time
+
+_lt_disabled_until: float = 0.0
+
+
+def set_language_tool_cooldown(duration_seconds: float = 300.0) -> None:
+    """Activate cooldown to prevent LanguageTool from restarting."""
+    global _lt_disabled_until
+    _lt_disabled_until = time.time() + duration_seconds
+
+
+def is_language_tool_in_cooldown() -> bool:
+    """Check if LanguageTool is currently blocked by memory cooldown."""
+    return time.time() < _lt_disabled_until
+
+
+def get_language_tool_cooldown_remaining() -> float:
+    """Return remaining seconds in cooldown."""
+    return max(0.0, _lt_disabled_until - time.time())

--- a/scripts/py/func/model_manager.py
+++ b/scripts/py/func/model_manager.py
@@ -122,8 +122,13 @@ def manage_models(logger, loaded_models, desired_names, threshold_mb, script_dir
         # scripts/py/func/model_manager.py:122
         load_buffer_mb = math.ceil(threshold_mb * 0.10)
         required_memory_mb = threshold_mb + load_buffer_mb + max_model_memory_footprint_mb
+        if avail_mb < threshold_mb:
+            from .stop_languagetool_server import evict_languagetool_process
+            evict_languagetool_process(logger)
         if avail_mb < required_memory_mb:
             if max_model_memory_footprint_mb > 0:
+                
+                
                 # IMPROVED LOG: Explain the calculation for "Required Memory"
                 log_msg = (
                     f"Postponing load: {_format_gb(avail_mb)} available is not enough. "

--- a/scripts/py/func/start_languagetool_server.py
+++ b/scripts/py/func/start_languagetool_server.py
@@ -122,9 +122,17 @@ def get_languagetool_jvm_args(for_self_test=False):
     }
 
 
+from .language_tool_cooldown import is_language_tool_in_cooldown, get_language_tool_cooldown_remaining
+
 def start_languagetool_server(logger, languagetool_jar_path, base_url, for_self_test=False):
-    # 1. Port extrahieren und URL säubern
-    # Falls base_url nur eine Zahl ist, mach eine URL draus
+    if is_language_tool_in_cooldown():
+        remaining = get_language_tool_cooldown_remaining()
+        if logger:
+            logger.info(f"LanguageTool start skipped: memory cooldown active ({remaining:.0f}s left).")
+        return False
+    # 1. extract and URL clean    
+    
+    # create URL when number
     if base_url.isdigit():
         port = base_url
     else:

--- a/scripts/py/func/stop_languagetool_server.py
+++ b/scripts/py/func/stop_languagetool_server.py
@@ -1,18 +1,29 @@
-# scripts/py/func/stop_languagetool_server.py:1
+# scripts/py/func/stop_languagetool_server.py
 import subprocess
+import psutil
+from .language_tool_cooldown import set_language_tool_cooldown
 
+def evict_languagetool_process(logger=None, cooldown_seconds=300.0):
+    """Emergency eviction of LanguageTool to free RAM, activating cooldown."""
+    set_language_tool_cooldown(cooldown_seconds)
+    for proc in psutil.process_iter(['pid', 'cmdline']):
+        try:
+            cmdline = proc.info.get('cmdline') or []
+            if any('languagetool' in str(arg).lower() for arg in cmdline):
+                proc.kill()
+                if logger:
+                    logger.warning(f"Evicted LanguageTool PID {proc.pid} due to low memory.")
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
 
 def stop_languagetool_server(logger, languagetool_process):
     if languagetool_process and languagetool_process.poll() is None:
-        if languagetool_process and hasattr(languagetool_process, 'wait'):
-            try:
-                languagetool_process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                languagetool_process.kill()
-        else:
+        try:
+            if hasattr(languagetool_process, 'terminate'):
+                languagetool_process.terminate()
+            languagetool_process.wait(timeout=0.5)
+        except (subprocess.TimeoutExpired, Exception):
             if hasattr(languagetool_process, 'kill'):
                 languagetool_process.kill()
-
-
 
 


### PR DESCRIPTION
…n on low RAM

- Introduce language_tool_cooldown module to track and enforce restart cooldowns
- Add evict_languagetool_process to stop_languagetool_server to terminate LT during memory pressure
- Trigger LanguageTool eviction in model_manager when available RAM drops below threshold
- Skip LanguageTool startup while memory cooldown is active in start_languagetool_server